### PR TITLE
Added FileListing & BuildLog

### DIFF
--- a/api.yaml
+++ b/api.yaml
@@ -23,6 +23,62 @@ paths:
             text/plain:
               schema:
                 $ref: '#/components/schemas/NixCacheInfo'
+  /log/{deriver}:
+    get:
+      summary: Get the build logs for a particular deriver.
+              This path exists if this binary cache is hydrated from Hydra.
+      operationId: getDeriverBuildLog
+      parameters:
+      - name: deriver
+        in: path
+        description: The full name of the deriver
+        required: true
+        example: bidkcs01mww363s4s7akdhbl6ws66b0z-ruby-2.7.3.drv 
+        schema:
+          type: string
+      responses:
+        200:
+          description: successful operation. This is usually compressed such as with brotli.
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: |
+                        unpacking sources
+                        unpacking source archive /nix/store/x3ir0dv32r6603df7myx14s308sfsh0c-source
+                        source root is source
+                        patching sources
+                        applying patch /nix/store/073hhn64isdlfbsjyr0sw78gyr9g7llg-source/patches/ruby/2.7/head/railsexpress/01-fix-broken-tests-caused-by-ad.patch
+                        patching file spec/ruby/core/process/groups_spec.rb
+                        patching file spec/ruby/library/etc/getgrgid_spec.rb
+                        patching file spec/ruby/library/etc/struct_group_spec.rb
+                        patching file test/ruby/test_process.rb
+                        applying patch /nix/store/073hhn64isdlfbsjyr0sw78gyr9g7llg-source/patches/ruby/2.7/head/railsexpress/02-improve-gc-stats.pa
+        404:
+          description: Not found
+          content: {}
+  /{storePathHash}.ls:
+    get:
+      summary: Get the file listings for a particular store-path (once you expand the NAR).
+      operationId: getNarFileListing
+      parameters:
+      - name: storePathHash
+        in: path
+        description: cryptographic hash of the store path
+        required: true
+        example: p4pclmv1gyja5kzc26npqpia1qqxrf0l
+        schema:
+          type: string
+      responses:
+        200:
+          description: successful operation. This is usually compressed such as with brotli.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/FileListing'
+        404:
+          description: Not found
+          content: {}
   /{storePathHash}.narinfo:
     head:
       summary: Check if a particular path exists quickly
@@ -126,6 +182,51 @@ components:
                        Binary caches are checked for binaries in order of ascending priority;
                        thus a higher number denotes a lower priority.
                        The binary cache https://cache.nixos.org has priority 40.
+    FileListingEntryType:
+      type: string
+      enum: [directory, regular]
+    FileListingDirectoryEntry:
+      type: object
+      required:
+        - type
+        - entries
+      properties:
+        type:
+          $ref: '#/components/schemas/FileListingEntryType'
+        entries:
+          type: object
+          additionalProperties:
+            oneOf:
+              - $ref: '#/components/schemas/FileListingFileEntry'
+              - $ref: '#/components/schemas/FileListingDirectoryEntry'
+    FileListingFileEntry:
+      type: object
+      required:
+        - type
+        - size
+        - narOffset
+      properties:
+        type:
+          $ref: '#/components/schemas/FileListingEntryType'
+        size:
+          type: integer
+          description: The size of the file
+        narOffset:
+          type: integer
+          description: The offset in bytes within the NAR
+        executable:
+          type: boolean
+          description: Whether this file should be made executable
+    FileListing:
+      type: object
+      properties:
+        version:
+          type: integer
+          description: The version of this current format
+        root:
+          oneOf:
+            - $ref: '#/components/schemas/FileListingDirectoryEntry'
+            - $ref: '#/components/schemas/FileListingFileEntry'
     NarInfo:
       type: object
       required:


### PR DESCRIPTION
Added two new API endpoints.

FileListing: an API endpoint that gives the file listing for a
particular NAR. I imagine this is useful for things like nix-index

BuildLog: if the binary cache uses Hydra, there seems to be a build log
accessable with it's output one can query.

fixes #1